### PR TITLE
Removing non-ASCII minus signs from lat/long field

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@ venue: Universidade Federal do Paraná
 address: Laboratório de Matemática e Desenho (LAMADE) no bloco PC, sala PC12.
 country: Brazil
 language: 'pt'
-latlng: –25.450937,–49.231519
+latlng: -25.450937,-49.231519
 humandate: Jun 30, 2015
 humantime: 9:00am - 5:00pm
 startdate: 2015-05-30


### PR DESCRIPTION
The website processor won't handle this as-is because of the non-ASCII minus signs.
